### PR TITLE
Lean Stratum Server

### DIFF
--- a/configs/example.js
+++ b/configs/example.js
@@ -12,6 +12,10 @@ const config = {};
 config.enabled = true;
 config.settings = {};
 
+// Stratum Configuration
+config.stratum = {};
+config.stratum.lean = false;
+
 // Banning Configuration
 config.settings.banning = {};
 config.settings.banning.banLength = 600000; // ms;

--- a/configs/main.js
+++ b/configs/main.js
@@ -12,6 +12,12 @@ const config = {};
 config.language = 'english';
 config.identifier = '';
 
+// Stratum Configuration
+config.stratum = {};
+config.stratum.lean = true;
+config.stratum.instance = 'stratum';
+// config.stratum.instance = 'master';
+
 // Logger Configuration
 config.logger = {};
 config.logger.logColors = true;

--- a/server/main/stratum.js
+++ b/server/main/stratum.js
@@ -16,6 +16,22 @@ const Stratum = function (logger, config, configMain) {
   process.setMaxListeners(0);
   this.forkId = process.env.forkId;
 
+  // Log New Share
+  this.handleShareProcessed = function(shareData, shareValid) {
+    // Processed Share was Accepted
+    if (shareValid) {
+      const address = shareData.addrPrimary.split('.')[0];
+      const text = _this.text.stratumSharesText1(shareData.difficulty, shareData.shareDiff, address, shareData.ip);
+      _this.logger['log']('Pool', _this.config.name, [text]);
+
+    // Processed Share was Rejected
+    } else {
+      const address = shareData.addrPrimary.split('.')[0];
+      const text = _this.text.stratumSharesText2(shareData.error, address, shareData.ip);
+      _this.logger['error']('Pool', _this.config.name, [text]);
+    }
+  };
+
   // Build Stratum from Configuration
   this.handleStratum = function() {
 
@@ -30,19 +46,7 @@ const Stratum = function (logger, config, configMain) {
 
     // Handle Stratum Share Events
     _this.stratum.on('pool.share', (shareData, shareValid) => {
-
-      // Processed Share was Accepted
-      if (shareValid) {
-        const address = shareData.addrPrimary.split('.')[0];
-        const text = _this.text.stratumSharesText1(shareData.difficulty, shareData.shareDiff, address, shareData.ip);
-        _this.logger['log']('Pool', _this.config.name, [text]);
-
-      // Processed Share was Rejected
-      } else {
-        const address = shareData.addrPrimary.split('.')[0];
-        const text = _this.text.stratumSharesText2(shareData.error, address, shareData.ip);
-        _this.logger['error']('Pool', _this.config.name, [text]);
-      }
+      _this.handleShareProcessed(shareData, shareValid);
     });
   };
 


### PR DESCRIPTION
Initial proposed lean stratum server update. This code is not finished (needs cleanup and tests etc.) but is fully functional.

It introduces a now configurable mode in which the remote stratum either emits a standard pool.share which is processed in the usual way or a pool.meta_share which is merely saves shareData to the master server 'current_sahres' table. The master server has a new event loop which parses all new saved shares and pushes them to the shareHandler.

The purpose of this update is to:
1. Minimise data traffic between the main server and remote stratum locations.
2. Reduce load of the remote stratum servers.

Lean stratum is configured as either master (processes shares in the usual way) or stratum (only saves shares to master server).